### PR TITLE
Correctly handle UTC and TZ offset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 parsetime
 *.o
 *.so
+*.pyc

--- a/parsetime.c
+++ b/parsetime.c
@@ -516,11 +516,6 @@ tod(struct tm *tm)
 
     if (sc_tokid == UTC) {
         /* Handle UTC offset */
-        hour += tm->tm_gmtoff / 3600;
-        hour %= 24;
-        minute += tm->tm_gmtoff / 60;
-        minute %= 60;
-        tm->tm_gmtoff = 0;
         utc_defined = 1;
         token();
     }
@@ -779,16 +774,12 @@ parsetime(int token_nr, char **token_arr, time_t *result)
 
     /* convert back to time_t
     */
-    runtime.tm_isdst = -1;
+
     runtimer = mktime(&runtime);
 
-    // Account for DST
-    if (utc_defined == 1 && runtime.tm_isdst == 1) {
-        if (nowtime.tm_isdst == 1) {
-            runtimer += 3600;
-        } else if (nowtime.tm_isdst  == 0) {
-            runtimer += 7200;
-        }
+    if (utc_defined == 1) {
+      // Remove gmtoff since mktime inserts it
+      runtimer += runtime.tm_gmtoff;
     }
 
     if (runtimer < 0) {

--- a/test/test_parsetime.py
+++ b/test/test_parsetime.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 import time
 from parsetime import parsetime
@@ -6,7 +7,7 @@ class ParsetimeTest(unittest.TestCase):
 
     @classmethod
     def setUp(self):
-        self.rtime = 1052136000
+        self.rtime = time.mktime(datetime.datetime(2003, 5, 5, 5, 0, 0, 0, None).timetuple())
 
     def test_init(self):
         ptime = parsetime('')
@@ -19,11 +20,11 @@ class ParsetimeTest(unittest.TestCase):
         ptime = parsetime('5:00 AM May 5 2003')
         self.assertEquals(self.rtime, ptime)
 
-        ptime = parsetime('11:00 AM UTC May 5 2003')
-        self.assertEquals(self.rtime, ptime)
+        ptime = parsetime('12:00 PM UTC May 5 2003')
+        self.assertEquals(1052136000, ptime)
 
-        ptime = parsetime('11:00 UTC May 5 2003')
-        self.assertEquals(self.rtime, ptime)
+        ptime = parsetime('12:00 UTC May 5 2003')
+        self.assertEquals(1052136000, ptime)
 
     def test_add_sec(self):
         ptime = parsetime('5:00 AM May 5 2003+1s')


### PR DESCRIPTION
Mktime inserts the tz info even if you change tm_gmtoff

Fix unit tests
